### PR TITLE
feat(searchBar): add user search & history

### DIFF
--- a/src/components/header/SearchMenu.js
+++ b/src/components/header/SearchMenu.js
@@ -1,11 +1,21 @@
 // @packages
 import { useEffect, useRef, useState } from 'react';
-//@scripts
+import { Link } from 'react-router-dom';
+// @scripts
 import { Return, Search } from '../../svg';
 import useClickOutside from '../../helpers/clickOutside';
+import {
+  getSearchHistory,
+  removeFromSearch,
+  search,
+  addToSearchHistory,
+} from '../../functions/user';
 
-export default function SearchMenu({ color, setShowSearchMenu }) {
+export default function SearchMenu({ color, setShowSearchMenu, token }) {
   const [iconVisible, setIconVisible] = useState(true);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [searchHistory, setSearchHistory] = useState([]);
+  const [results, setResults] = useState([]);
   const menu = useRef(null);
   const input = useRef(null);
 
@@ -16,6 +26,36 @@ export default function SearchMenu({ color, setShowSearchMenu }) {
   useEffect(() => {
     input.current.focus();
   }, []);
+
+  useEffect(() => {
+    getHistory();
+    // eslint-disable-next-line
+  }, []);
+
+  const getHistory = async () => {
+    const res = await getSearchHistory(token);
+    setSearchHistory(res);
+    console.log(res);
+  };
+
+  const searchHandler = async () => {
+    if (searchTerm === '') {
+      setResults([]);
+    } else {
+      const res = await search(searchTerm, token);
+      setResults(res);
+    }
+  };
+
+  const addToSearchHistoryHandler = async (searchUser) => {
+    await addToSearchHistory(searchUser, token);
+    getHistory();
+  };
+
+  const handleRemove = async (searchUser) => {
+    await removeFromSearch(searchUser, token);
+    getHistory();
+  };
 
   return (
     <div className='header_left search_area scrollbar' ref={menu}>
@@ -49,16 +89,60 @@ export default function SearchMenu({ color, setShowSearchMenu }) {
             onBlur={() => {
               setIconVisible(true);
             }}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            onKeyUp={searchHandler}
+            value={searchTerm}
           />
         </div>
       </div>
-      <div className='search_history_header'>
-        <span>Recent searches</span>
-        {/*eslint-disable-next-line*/}
-        <a>Edit</a>
+      {!results.length && (
+        <div className='search_history_header'>
+          <span>Recent searches</span>
+          {/*eslint-disable-next-line*/}
+          <a>Edit</a>
+        </div>
+      )}
+      <div className='search_history scrollbar'>
+        {searchHistory &&
+          !results.length &&
+          searchHistory
+            .sort((a, b) => {
+              return new Date(b.createdAt) - new Date(a.createdAt);
+            })
+            .map((user) => (
+              <div className='search_user_item hover1' key={user?._id}>
+                <Link
+                  className='flex'
+                  to={`/profile/${user?.user.username}`}
+                  onClick={() => addToSearchHistoryHandler(user?.user._id)}>
+                  <img src={user?.user.picture} alt='' />
+                  <span>
+                    {user?.user.first_name} {user?.user.last_name}
+                  </span>
+                </Link>
+                <i
+                  className='exit_icon'
+                  onClick={() => {
+                    handleRemove(user?.user._id);
+                  }}></i>
+              </div>
+            ))}
       </div>
-      <div className='search_history'></div>
-      <div className='search_results scrollbar'></div>
+      <div className='search_results scrollbar'>
+        {results &&
+          results.map((user) => (
+            <Link
+              to={`/profile/${user?.username}`}
+              className='search_user_item hover1'
+              onClick={() => addToSearchHistoryHandler(user?._id)}
+              key={user?._id}>
+              <img src={user?.picture} alt='' />
+              <span>
+                {user?.first_name} {user?.last_name}
+              </span>
+            </Link>
+          ))}
+      </div>
     </div>
   );
 }

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -69,7 +69,11 @@ export default function Header({ getAllPosts, page }) {
         </div>
       </div>
       {showSearchMenu && (
-        <SearchMenu color={color} setShowSearchMenu={setShowSearchMenu} />
+        <SearchMenu
+          color={color}
+          setShowSearchMenu={setShowSearchMenu}
+          token={user?.token}
+        />
       )}
       <div className='header_middle'>
         <Link

--- a/src/components/header/style.css
+++ b/src/components/header/style.css
@@ -11,7 +11,7 @@ header {
   color: var(--color-primary);
 }
 
-/*----Header Left----*/
+/* Header Left */
 .header_left {
   display: flex;
   align-items: center;
@@ -50,9 +50,9 @@ header {
 .search input::placeholder {
   transform: translateY(-1px);
 }
-/*----Header Left End----*/
+/* Header Left End */
 
-/*---Header Middle-----*/
+/* Header Middle */
 .header_middle {
   display: flex;
   align-items: center;
@@ -109,9 +109,9 @@ header {
   font-size: 13px;
   color: #fff;
 }
-/*----Header Middle End----*/
+/* Header Middle End */
 
-/*---Header Right-----*/
+/* Header Right */
 .header_right {
   display: flex;
   position: absolute;
@@ -169,9 +169,9 @@ header {
   font-size: 13px;
   color: #fff;
 }
-/*---Header Right End----*/
+/* Header Right End */
 
-/*----Search Menu----*/
+/* searchMenu */
 .search_area {
   position: absolute;
   align-items: flex-start;
@@ -239,9 +239,50 @@ header {
   cursor: pointer;
   color: var(--blue-color);
 }
-/*----Search Menu End----*/
 
-/*----Search All Menu-----*/
+.search_results {
+  width: 100%;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.search_history {
+  width: 100%;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.search_user_item {
+  position: relative;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 5px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.search_user_item img {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.search_user_item span {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.search_user_item i {
+  position: absolute;
+  right: 10px;
+  transform: scale(0.6); 
+}
+/* searchMenu End */
+
+/* allMenu */
 .all_menu {
   position: absolute;
   right: -9rem;
@@ -381,9 +422,8 @@ header {
   justify-content: center;
   background: var(--bg-third);
 }
-/*----Search All Menu End----*/
 
-/*----User menu----*/
+/* userMenu */
 .mmenu {
   padding: 0 0.3rem;
   position: absolute;
@@ -514,9 +554,9 @@ header {
   width: 20px;
   height: 20px;
 }
-/*---User Menu End---*/
+/* userMenu End */
 
-/*---Active Header---*/
+/* Active Header */
 .active_header {
   background: var(--light-blue-color);
 }
@@ -529,9 +569,7 @@ header {
   background: var(--light-blue-color);
   color: var(--light-teal);
 }
-/*---Active Header End---*/
 
-/*---responsive----------*/
 @media (max-width: 1295px) {
   .middle_icon {
     width: 90px;

--- a/src/components/post/PostMenu.js
+++ b/src/components/post/PostMenu.js
@@ -97,7 +97,7 @@ export default function PostMenu({
           <MenuItem
             icon='trash_icon'
             title='Move to trash'
-            subtitle='This post will be permanently deleted'
+            subtitle='This post will be permanently deleted.'
           />
         </div>
       )}

--- a/src/functions/user.js
+++ b/src/functions/user.js
@@ -192,3 +192,74 @@ export const deleteRequest = async (id, token) => {
     return error.response.data.message;
   }
 };
+
+export const search = async (searchTerm, token) => {
+  try {
+    const { data } = await axios.post(
+      `${process.env.REACT_APP_BACKEND_URL}/api/v1/user/search/${searchTerm}`,
+      {},
+
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    return data;
+  } catch (error) {
+    return error.response.data.message;
+  }
+};
+
+export const addToSearchHistory = async (searchUser, token) => {
+  try {
+    const { data } = await axios.put(
+      `${process.env.REACT_APP_BACKEND_URL}/api/v1/user/addToSearchHistory`,
+      { searchUser },
+
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    return data;
+  } catch (error) {
+    return error.response.data.message;
+  }
+};
+
+export const getSearchHistory = async (token) => {
+  try {
+    const { data } = await axios.get(
+      `${process.env.REACT_APP_BACKEND_URL}/api/v1/user/getSearchHistory`,
+
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    return data;
+  } catch (error) {
+    return error.response.data.message;
+  }
+};
+
+export const removeFromSearch = async (searchUser, token) => {
+  try {
+    const { data } = await axios.put(
+      `${process.env.REACT_APP_BACKEND_URL}/api/v1/user/removeFromSearch`,
+      { searchUser },
+
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    return data;
+  } catch (error) {
+    return error.response.data.message;
+  }
+};

--- a/src/pages/home/index.js
+++ b/src/pages/home/index.js
@@ -24,8 +24,8 @@ export default function Home({
   const middle = useRef(null);
 
   useEffect(() => {
-    setHeight(middle.current.clientHeight + 35);
-  }, [home_loading, height]);
+    setHeight(middle.current.clientHeight + 65);
+  }, [posts, height]);
 
   // eslint-disable-next-line
   const [{ loading, error, profile }, dispatch] = useReducer(profileReducer, {

--- a/src/pages/profile/index.js
+++ b/src/pages/profile/index.js
@@ -158,7 +158,7 @@ export default function Profile({ getAllPosts }) {
       <div className='profile_top' ref={profileTop}>
         <div className='profile_container'>
           <Cover
-            cover={profile.cover}
+            cover={profile?.cover}
             visitor={visitor}
             photos={photos?.resources}
           />


### PR DESCRIPTION
Added functionality to search for other users within the search bar of the header (navbar) and take the user to the other user's profile page when clicked. The user's search history is persisted to the backend and shown on the UI with the option to remove previous searches. 

![userSearch](https://user-images.githubusercontent.com/77213293/211219671-fecbe3e4-058a-4ef5-8545-e06fb0167103.png)
