### PR TITLE
feat(editPost): add cancel & save bttns

### DIFF
--- a/src/components/post/PostMenu.js
+++ b/src/components/post/PostMenu.js
@@ -47,7 +47,8 @@ export default function PostMenu({
   };
 
   const editHandler = async () => {
-    setEditingPost(true)
+    setEditingPost(true);
+    setShowMenu(false);
   };
 
   return (

--- a/src/components/post/index.js
+++ b/src/components/post/index.js
@@ -79,6 +79,17 @@ export default function Post({ post, user, profile }) {
     setCount((prev) => prev + 3);
   };
 
+  const cancelUpdatingPostComment = () => {
+    setEditingPost(false);
+    setText(post?.text);
+  }
+
+  const updatePostComment = () => {
+    setEditingPost(false);
+    // Call function to persist comment here
+    return;
+  };
+
   return (
     <div
       className='post'
@@ -135,17 +146,30 @@ export default function Post({ post, user, profile }) {
         <>
           {!editingPost && <div className='post_text'>{text}</div>}
           {editingPost && (
-            <textarea
-              ref={textRef}
-              maxLength='250'
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              className={'post_input'}
-              style={{
-                paddingTop: `Math.abs(textRef.current.value.length * 0.1 - 32)
+            <div>
+              <textarea
+                ref={textRef}
+                maxLength='250'
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                className={'post_input'}
+                style={{
+                  paddingTop: `Math.abs(textRef.current.value.length * 0.1 - 32)
                 }%`,
-              }}
-              ></textarea>
+                }}></textarea>
+              <div className='edit_comment_btn_container'>
+                <button
+                  className='gray_bttn opacity_btn edit_comment_btn'
+                  onClick={() => cancelUpdatingPostComment()}>
+                  Cancel
+                </button>
+                <button
+                  className='teal_bttn edit_comment_btn'
+                  onClick={() => updatePostComment()}>
+                  Save
+                </button>
+              </div>
+            </div>
           )}
           {post?.images && post?.images.length && (
             <div

--- a/src/components/post/style.css
+++ b/src/components/post/style.css
@@ -79,6 +79,7 @@
 
 .post_text {
   padding: 0 15px 10px 15px;
+  word-wrap: break-word;
 }
 
 /* Grid Images */
@@ -526,12 +527,23 @@
   resize: none;
   padding: 5px 15px;
   margin-bottom: 10px;
-  width: 470px;
+  width: 95%; 
   margin-left: 1px;
   font-family: inherit;
-  font-size: 24px;
   background: var(--bg-primary);
   color: var(--color-primary);
+  word-wrap: break-word;
+}
+
+.edit_comment_btn_container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-bottom: 3px;
+}
+
+.edit_comment_btn {
+  margin-left: 7px;
+  margin-right: 7px;
 }
 /* Post Menu End */
 

--- a/src/pages/home/home.css
+++ b/src/pages/home/home.css
@@ -16,7 +16,7 @@
   .send_verification,
   .createPost,
   .post {
-    width: 550px;
+    width: 550px !important;
     margin-left: -70px;
   }
   .right_home {
@@ -67,7 +67,7 @@
   .send_verification,
   .createPost,
   .post {
-    width: 540px;
+    width: 540px !important;
     margin-left: 9%;
   }
   .right_home {
@@ -88,12 +88,17 @@
   .send_verification,
   .createPost,
   .post {
-    width: 115%;
+    width: 115% !important;
   }
   .contact span {
     font-size: 12px;
   }
   .contacts_header_right {
+    display: none;
+  }
+}
+@media (max-width: 815px) {
+  .right_home {
     display: none;
   }
 }
@@ -103,9 +108,6 @@
   }
 }
 @media (max-width: 780px) {
-  .right_home {
-    display: none;
-  }
   .send_verification,
   .createPost,
   .post {
@@ -124,7 +126,7 @@
   .send_verification,
   .createPost,
   .post {
-    width: 450px;
+    width: 450px !important;
     margin: 0 auto;
     margin-bottom: 10px;
   }
@@ -145,14 +147,14 @@
   .send_verification,
   .createPost,
   .post {
-    width: 400px;
+    width: 400px !important;
   }
 }
 @media (max-width: 457px) {
   .send_verification,
   .createPost,
   .post {
-    width: 390px;
+    width: 390px !important;
   }
   .createPost_icon svg {
     width: 19px;
@@ -165,7 +167,7 @@
   .createPost,
   .post,
   .send_Verification {
-    width: 100%;
+    width: 100% !important;
   }
   .createPost_Icon {
     font-size: 12px;


### PR DESCRIPTION
Implemented save & cancel buttons to the UI for updating an owner provided comment for the post

![edit-post](https://github.com/rooster-app/rooster-frontend/assets/77213293/b6978d17-fa17-498e-8748-78bad5e9250f)

after _Edit Post_ 

![editing-post-text](https://github.com/rooster-app/rooster-frontend/assets/77213293/ba51a07a-163f-48aa-ab0b-ed4dab0f0c40)

after  _Save_

![edited-post-text](https://github.com/rooster-app/rooster-frontend/assets/77213293/39db759f-c8d7-467b-99c1-5b5b6be20e53)

Future work: Add a function to persist the updated text to the backend API
